### PR TITLE
Ensure all tables have a PK

### DIFF
--- a/database/migrations/2014_10_12_100000_create_password_resets_table.php
+++ b/database/migrations/2014_10_12_100000_create_password_resets_table.php
@@ -13,6 +13,7 @@ return new class extends Migration {
     public function up()
     {
         Schema::create('password_resets', function (Blueprint $table) {
+            $table->id();
             $table->string('email')->index();
             $table->string('token');
             $table->timestamp('created_at')->nullable();


### PR DESCRIPTION
This is useful when deploying on managed databases (like UpCloud/DO) where this is a requirement.