### PR TITLE
Add Docker Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ yarn-error.log
 .php-cs-fixer.cache
 rr
 .rr.yaml
+/docker/dbdata

--- a/README.md
+++ b/README.md
@@ -175,6 +175,58 @@ public function boot()
 
 Now head over to the login page in your roadmap software and view the log in button in action. The title of the button can be set with the `.env` variable: `SSO_LOGIN_TITLE=`
 
+
+## Docker Support
+
+### Getting up and running...
+
+Go into docker folder and run:
+`docker-compose up -d --build`
+
+Set your database .env variables:
+```
+DB_CONNECTION=mysql
+DB_HOST=roadmap-db
+DB_PORT=3306
+DB_DATABASE=roadmap
+DB_USERNAME=root
+DB_PASSWORD=secret
+```
+
+Composer Install:
+
+`docker exec -it roadmap composer install`
+
+NPM Install:
+
+`docker exec -it roadmap npm install`
+
+Running artisan commands:
+
+`docker exec -it roadmap php artisan <command>`
+
+The Application will be running on `localhost:1337` and PhpMyAdmin is running on `localhost:8010`
+
+### Docker Considerations
+
+There are a few heroicons that were giving issues when running locally with docker.
+
+```
+Unable to locate a class or view for component <insert heroicon name here>
+```
+The problem was resolved by simply changing the following icons:
+
+x-heroicon-o-chevron-down -> x-heroicon-s-chevron-down (group.blade.php)
+heroicon-o-chat -> heroicon-s-chat (CommentResource)
+heroicon-o-archive -> heroicon-s-archive (ItemResource)
+heroicon-o-x-circle -> heroicon-o-collection (notifications.blade.php)
+
+Related Issues:
+
+[laravel-filament/filament#2677](https://github.com/laravel-filament/filament/issues/2677)
+
+[blade-ui-kit/blade-heroicons#9](https://github.com/blade-ui-kit/blade-heroicons/issues/9)
+
 ## Testing
 
 ```bash

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,46 @@
+FROM php:8.1.5-fpm-alpine3.15
+
+WORKDIR /var/www/html
+
+#install GD
+RUN apk add --no-cache freetype libpng libjpeg-turbo   \
+  && apk add --virtual build-deps freetype-dev libpng-dev libjpeg-turbo-dev \
+  && docker-php-ext-configure gd  --with-freetype=/usr/include/  --with-jpeg=/usr/include/ \
+  && nproc=$(grep -c ^processor /proc/cpuinfo 2>/dev/null || 1) \
+  && docker-php-ext-install -j${nproc} gd \
+  && apk del build-deps
+
+RUN apk add --no-cache libzip-dev && docker-php-ext-configure zip \
+    && docker-php-ext-install zip
+
+# Install nodejs
+RUN apk add npm
+
+# Upgrading Node
+RUN npm cache clean -f
+RUN npm install -g n
+
+RUN apk add --no-cache icu-dev  && docker-php-ext-configure intl \
+      && docker-php-ext-install intl pdo pdo_mysql sockets
+
+# Get latest Composer
+COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+
+RUN chown -R www-data:www-data /var/www
+
+# Expose port 9000 and start php-fpm server
+EXPOSE 9000
+CMD ["php-fpm"]
+
+
+# Get latest Composer
+COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+
+# Set working directory
+WORKDIR /var/www
+
+RUN chown -R www-data:www-data /var/www
+
+# Expose port 9000 and start php-fpm server
+EXPOSE 9000
+CMD ["php-fpm"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,67 @@
+version: '3'
+
+services:
+  roadmap:
+    build:
+      context: ""
+      dockerfile: Dockerfile
+    container_name: roadmap
+    tty: true
+    environment:
+      SERVICE_NAME: roadmap
+      SERVICE_TAGS: dev
+    working_dir: /var/www
+    volumes:
+      - ../.:/var/www
+      - ./php/local.ini:/usr/local/etc/php/conf.d/local.ini
+    networks:
+      - roadmap
+
+  roadmap-webserver:
+    image: nginx:alpine
+    container_name: roadmap-webserver
+    tty: true
+    ports:
+      - "1337:81"
+      - "5577:443"
+    volumes:
+      - ../.:/var/www/
+      - ./nginx/:/etc/nginx/conf.d/
+    networks:
+      - roadmap
+    depends_on:
+      - roadmap
+
+  roadmap-db:
+    image: mysql:5.7.22
+    container_name: roadmap-db
+    restart: unless-stopped
+    tty: true
+    ports:
+      - "3311:3306"
+    environment:
+      MYSQL_DATABASE: roadmap
+      MYSQL_ROOT_PASSWORD: secret
+      SERVICE_TAGS: dev
+      SERVICE_NAME: roadmap-mysql
+    volumes:
+      - ./mysql/setup.sql:/docker-entrypoint-initdb.d/setup.sql
+      - ./dbdata:/var/lib/mysql/
+      - ./mysql/my.cnf:/etc/mysql/my.cnf
+    networks:
+      - roadmap
+
+  roadmap-myadmin:
+    image: phpmyadmin
+    container_name: roadmap-myadmin
+    restart: always
+    ports:
+      - 8010:80
+    environment:
+      - PMA_ARBITRARY=1
+    networks:
+      - roadmap
+
+networks:
+  roadmap:
+    driver: bridge

--- a/docker/mysql/my.cnf
+++ b/docker/mysql/my.cnf
@@ -1,0 +1,3 @@
+[mysqld]
+general_log = 1
+general_log_file = /var/lib/mysql/general.log

--- a/docker/mysql/setup.sql
+++ b/docker/mysql/setup.sql
@@ -1,0 +1,2 @@
+-- create the databases
+CREATE DATABASE IF NOT EXISTS roadmap;

--- a/docker/nginx/app.conf
+++ b/docker/nginx/app.conf
@@ -1,0 +1,21 @@
+server {
+    listen 81;
+    server_name localhost;
+    index index.php index.html;
+    error_log  /var/log/nginx/error.log;
+    access_log /var/log/nginx/access.log;
+    root /var/www/public;
+    location ~ \.php$ {
+        try_files $uri =404;
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass  roadmap:9000;
+        fastcgi_index index.php;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
+    }
+    location / {
+        try_files $uri $uri/ /index.php?$query_string;
+        gzip_static on;
+    }
+}

--- a/docker/php/local.ini
+++ b/docker/php/local.ini
@@ -1,0 +1,5 @@
+upload_max_filesize=40M
+post_max_size=40M
+php artisan cache:clear
+chmod -R 777 storage/
+composer dump-autoload

--- a/docker/php/local.ini
+++ b/docker/php/local.ini
@@ -1,5 +1,2 @@
 upload_max_filesize=40M
 post_max_size=40M
-php artisan cache:clear
-chmod -R 777 storage/
-composer dump-autoload


### PR DESCRIPTION
## What?
This Pull Request adds docker support to Roadmap for self contained local development as requested in https://github.com/ploi-deploy/roadmap/issues/60

## Getting up and running..
Go into docker folder and run:
`docker-compose up -d --build`

Running artisan commands:
`docker exec -it roadmap php artisan <command>`

Will be running on `localhost:1337` and PhpMyAdmin is running on `localhost:8010` 

## Considerations?

There are a few heroicons that were giving issues when running locally with docker.

```
Unable to locate a class or view for component <insert heroicon name here>
```
The problem was resolved by simply changing the following icons:

x-heroicon-o-chevron-down -> x-heroicon-s-chevron-down (group.blade.php)
heroicon-o-chat -> heroicon-s-chat (CommentResource)
heroicon-o-archive -> heroicon-s-archive (ItemResource)
heroicon-o-x-circle -> heroicon-o-collection (notifications.blade.php)

Related Issues:

https://github.com/laravel-filament/filament/issues/2677
https://github.com/blade-ui-kit/blade-heroicons/issues/9