### PR TITLE
Update installation instructions for front-end assets in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ And login with the credentials you've provided, the user you've created will aut
 
 ## Deployment
 
-To manage your servers and sites, we recommend using [Ploi.io](https://ploi.io/?ref=) to speed up things, obviously you're free to choose however you'd like to deploy this piece of software 💙
+To manage your servers and sites, we recommend using [Ploi.io](https://ploi.io/?ref=roadmap-readme) to speed up things, obviously you're free to choose however you'd like to deploy this piece of software 💙
 
 That being said, here's an deployment script example:
 
@@ -64,7 +64,7 @@ php artisan route:cache
 php artisan view:clear
 php artisan migrate --force
 
-npm install
+npm ci
 npm run production
 
 echo "🚀 Application deployed!"
@@ -209,7 +209,7 @@ Composer Install:
 
 NPM Install:
 
-`docker exec -it roadmap npm install`
+`docker exec -it roadmap npm ci`
 
 Running artisan commands:
 

--- a/app/Console/Commands/Install.php
+++ b/app/Console/Commands/Install.php
@@ -72,10 +72,10 @@ class Install extends Command
 
     protected function runNpm()
     {
-        if ($this->confirm('Do you want to run npm install & npm run production to get the assets ready?')) {
+        if ($this->confirm('Do you want to run npm ci & npm run production to get the assets ready?')) {
             $this->info('Running NPM..');
 
-            shell_exec('npm install');
+            shell_exec('npm ci');
             shell_exec('npm run production');
 
             $this->info('NPM installation & mixing production done!');


### PR DESCRIPTION
- use `npm ci` instead of `npm install` (see: https://stackoverflow.com/a/53325242/2859139 - TLDR: installs the exact versions as defined in `package-lock.json`)
- update the empty `?ref=` parameter to the ploi website