### PR TITLE
Now really fix dashboard recent items to not show private items

### DIFF
--- a/app/Filament/Pages/Settings.php
+++ b/app/Filament/Pages/Settings.php
@@ -143,13 +143,13 @@ class Settings extends SettingsPage
                                         1 => 1,
                                         2 => 2,
                                     ])->default(1),
-                                    Toggle::make('must_have_board')
-                                        ->reactive()
-                                        ->visible(fn ($get) => $get('type') === 'recent-items')
-                                        ->helperText('Enable this to show items that have a board'),
                                     Toggle::make('must_have_project')
-                                        ->visible(fn ($get) => $get('must_have_board') && $get('type') === 'recent-items')
-                                        ->helperText('Enable this to show items that have a project'),
+                                          ->reactive()
+                                          ->visible(fn ($get) => $get('type') === 'recent-items')
+                                          ->helperText('Enable this to show items that have a project'),
+                                    Toggle::make('must_have_board')
+                                        ->visible(fn ($get) => $get('must_have_project') && $get('type') === 'recent-items')
+                                        ->helperText('Enable this to show items that have a board'),
                                 ])->helperText('Determine which items you want to show on the dashboard (for all users).'),
                         ]),
 

--- a/app/Models/Item.php
+++ b/app/Models/Item.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Str;
 use App\Enums\InboxWorkflow;
 use App\Settings\GeneralSettings;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Spatie\Activitylog\ActivitylogServiceProvider;
@@ -91,14 +92,14 @@ class Item extends Model
         return $query->orderBy('total_votes', 'desc');
     }
 
-    public function scopeVisibleForCurrentUser($query)
+    public function scopeVisibleForCurrentUser(Builder $query)
     {
         if (auth()->user()?->hasAdminAccess()) {
             return $query;
         }
 
         return $query->where('private', false)
-                     ->when($this->project_id, fn ($query) => $query->whereRelation('project', 'private', false));
+                     ->when($query->has('project'), fn (Builder $query) => $query->whereRelation('project', 'private', false));
     }
 
     public function scopeForInbox($query)

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -19,6 +19,10 @@ class Project extends Model
         'private',
     ];
 
+    protected $casts = [
+        'private' => 'boolean',
+    ];
+
     public function boards()
     {
         return $this->hasMany(Board::class)->orderBy('sort_order');

--- a/tests/Feature/Controllers/HomeControllerTest.php
+++ b/tests/Feature/Controllers/HomeControllerTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Models\Item;
 use App\Enums\UserRole;
 use App\Models\Project;
 use function Pest\Laravel\get;
@@ -24,14 +25,43 @@ test('the dashboard items are shown', function ($setting, $value) {
     'recent comments' => ['setting' => ["type" => "recent-comments", "column_span" => 1, "must_have_board" => false, "must_have_project" => false], 'value' => 'Recent activities'],
 ]);
 
-test('private projects are not visible in navbar for users', function(?UserRole $userRole, bool $shouldBeVisible) {
+test('recent items will not contain private items for users', function (?UserRole $userRole, bool $shouldBeVisible) {
+    GeneralSettings::fake(['dashboard_items' => [["type" => "recent-items", "column_span" => 1, "must_have_board" => false, "must_have_project" => false]]]);
+
+    Item::factory()->private()->create(['title' => 'Private item']);
+
+    createAndLoginUser(['role' => $userRole]);
+
+    get('/')->{$shouldBeVisible ? 'assertSeeText' : 'assertDontSeeText'}('Private item');
+})->with([
+    'User' => [UserRole::User, false],
+    'Employee' => [UserRole::Employee, true],
+    'Admin' => [UserRole::Admin, true],
+]);
+
+test('recent items will not contain items from private projects for users', function (?UserRole $userRole, bool $shouldBeVisible) {
+    GeneralSettings::fake(['dashboard_items' => [["type" => "recent-items", "column_span" => 1, "must_have_board" => false, "must_have_project" => true]]]);
+
+    $project = Project::factory()->private()->create();
+    Item::factory()->for($project)->create(['title' => 'Item in private project']);
+
+    createAndLoginUser(['role' => $userRole]);
+
+    get('/')->{$shouldBeVisible ? 'assertSeeText' : 'assertDontSeeText'}('Item in private project');
+})->with([
+    'User' => [UserRole::User, false],
+    'Employee' => [UserRole::Employee, true],
+    'Admin' => [UserRole::Admin, true],
+]);
+
+test('private projects are not visible in navbar for users', function (?UserRole $userRole, bool $shouldBeVisible) {
     $project = Project::factory()->private()->create();
 
     createAndLoginUser(['role' => $userRole]);
 
     get('/')->{$shouldBeVisible ? 'assertSeeText' : 'assertDontSeeText'}($project->title);
 })->with([
-    [UserRole::User, false],
-    [UserRole::Employee, true],
-    [UserRole::Admin, true],
+    'User' => [UserRole::User, false],
+    'Employee' => [UserRole::Employee, true],
+    'Admin' => [UserRole::Admin, true],
 ]);


### PR DESCRIPTION
* Fix to not show private items and public items in private projects on dashboard for users
* Flipped "Must have project" and "Must have board" for "Recent items" in settings, since an item cannot have a board without a project