### PR TITLE
Make boards sortable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
 /node_modules
+/node_modules.nosync
 /public/hot
 /public/storage
 /storage/*.key
 /vendor
+/vendor.nosync
 .env
 .env.backup
 .phpunit.result.cache

--- a/app/Filament/Resources/ItemResource.php
+++ b/app/Filament/Resources/ItemResource.php
@@ -108,7 +108,7 @@ class ItemResource extends Resource
                 Tables\Columns\TextColumn::make('total_votes')->label('Votes')->sortable()->toggleable()->toggledHiddenByDefault(),
                 Tables\Columns\TextColumn::make('comments_count')->label('Comments')->counts('comments')->sortable()->toggleable()->toggledHiddenByDefault(),
                 Tables\Columns\TextColumn::make('project.title'),
-                Tables\Columns\TextColumn::make('board.title'),
+                Tables\Columns\TextColumn::make('board.title')->sortable(),
                 Tables\Columns\TextColumn::make('user.name'),
                 Tables\Columns\TagsColumn::make('assignedUsers.name')->visible(auth()->user()->hasRole(UserRole::Admin))->toggleable()->toggledHiddenByDefault(),
                 Tables\Columns\TextColumn::make('created_at')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "roadmap",
+    "name": "rdmp",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {


### PR DESCRIPTION
This PR introduces the ability to make the board title sortable in the Items index page. 

Currently it is hard to see which tasks are done/live and which are still planned, because the `board.title` column is a plain text (just like the others), so that the board title doesn't jump out. 

Allowing it to sort by this means that you can group all `planned` and `done` items, making it easier to scan.