### PR TITLE
Fixed sso provider wrap key null issue

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,7 +64,8 @@ SSO_CALLBACK=${APP_URL}/oauth/callback
 # for example: { "data": "id": "name": "John Doe", "email": "john@example.com" }
 # If you would like to use a custom key instead of data, you may define it here.
 # you can also do something like 'data.user' if its nested.
-# or you can set it to null if sso provider user endpoint response is not wrapped in a key.
+# or you can set it to nothing (do not set it to value 'null'. just leave it empty value) 
+# if sso provider user endpoint response is not wrapped in a key.
 SSO_PROVIDER_USER_ENDPOINT_DATA_WRAP_KEY="data"
 # The keys that should be present in the sso provider user endpoint response
 SSO_PROVIDER_USER_ENDPOINT_KEYS="id,email,name"

--- a/README.md
+++ b/README.md
@@ -140,7 +140,9 @@ SSO_CALLBACK=${APP_URL}/oauth/callback
 # Mostly, your sso provider user endpoint response is wrapped in a `data` key.
 # for example: { "data": "id": "name": "John Doe", "email": "john@example.com" }
 # If you would like to use a custom key instead of data, you may define it here.
-# or you can set it to null if sso provider user endpoint response is not wrapped in a key.
+# you can also do something like 'data.user' if its nested.
+# or you can set it to nothing (do not set it to value 'null'. just leave it empty value) 
+# if sso provider user endpoint response is not wrapped in a key.
 SSO_PROVIDER_USER_ENDPOINT_DATA_WRAP_KEY="data"
 # The keys that should be present in the sso provider user endpoint response
 SSO_PROVIDER_USER_ENDPOINT_KEYS="id,email,name"

--- a/app/SocialProviders/SsoProvider.php
+++ b/app/SocialProviders/SsoProvider.php
@@ -80,12 +80,12 @@ class SsoProvider extends AbstractProvider implements ProviderInterface
         $providerUserEndpointKeys = config('services.sso.provider_user_endpoint_keys') ?? 'id,email,name';
         $providerId = config('services.sso.provider_id') ?? 'id';
 
-        if($providerUserEndpointDataWrapKey !== null) {
+        if($providerUserEndpointDataWrapKey) {
             $user = Arr::get($user, $providerUserEndpointDataWrapKey);
         }
         
         if ($user === null || !Arr::has($user, explode(',', $providerUserEndpointKeys))) {
-            if($providerUserEndpointDataWrapKey !== null) {
+            if($providerUserEndpointDataWrapKey) {
               throw new RuntimeException("The SSO user endpoint should return an {$providerUserEndpointKeys} in the `{$providerUserEndpointDataWrapKey}` field of the JSON response.");
             } else {
               throw new RuntimeException("The SSO user endpoint should return an {$providerUserEndpointKeys} in the JSON response.");

--- a/config/services.php
+++ b/config/services.php
@@ -45,7 +45,8 @@ return [
          * for example: { "data": "id": "name": "John Doe", "email": "john@example.com" }
          * If you would like to use a custom key instead of data, you may define it here.
          * you can also set something like 'data.user' if its nested.
-         * or you can set it to null if sso provider user endpoint response is not wrapped in a key.
+         * or you can set it to nothing (do not set it to value 'null'. just leave it empty value) 
+         * if sso provider user endpoint response is not wrapped in a key.
          */
         'provider_user_endpoint_data_wrap_key' => env('SSO_PROVIDER_USER_ENDPOINT_DATA_WRAP_KEY'),
         // The keys that should be present in the sso provider user endpoint response


### PR DESCRIPTION
Hi @Cannonb4ll.

In the last #156 PR. we had a if check `$providerUserEndpointDataWrapKey !== null`. 

Since my own sso provider does not wrap the response in a key like `data`. i set `SSO_PROVIDER_USER_ENDPOINT_DATA_WRAP_KEY=` to empty. 

but this `$providerUserEndpointDataWrapKey` defaults to `data` if I set `SSO_PROVIDER_USER_ENDPOINT_DATA_WRAP_KEY=null`. that's why I pr this fix to the original #156.

Can you check this pr with your current sso implementation so it doesn't break existing installations. 

Sorry for any inconvenience <3 