### PR TITLE
Customise date time format

### DIFF
--- a/app/Filament/Resources/BoardResource.php
+++ b/app/Filament/Resources/BoardResource.php
@@ -44,7 +44,7 @@ class BoardResource extends Resource
                 Tables\Columns\TextColumn::make('title'),
                 Tables\Columns\TextColumn::make('project.title'),
                 Tables\Columns\TextColumn::make('created_at')
-                    ->dateTime()
+                    ->dateTime(Auth()->user()->date_time_format )
                     ->sortable()
                     ->label('Date'),
             ])

--- a/app/Filament/Resources/ChangelogResource.php
+++ b/app/Filament/Resources/ChangelogResource.php
@@ -68,8 +68,8 @@ class ChangelogResource extends Resource
                 Tables\Columns\TextColumn::make('title')->searchable()->wrap(),
                 Tables\Columns\BooleanColumn::make('published')
                     ->getStateUsing(fn ($record) => filled($record->published_at) && now()->greaterThanOrEqualTo($record->published_at)),
-                Tables\Columns\TextColumn::make('published_at')->dateTime()->since()->sortable(),
-                Tables\Columns\TextColumn::make('created_at')->dateTime()->sortable(),
+                Tables\Columns\TextColumn::make('published_at')->dateTime(Auth()->user()->date_time_format)->since()->sortable(),
+                Tables\Columns\TextColumn::make('created_at')->dateTime(Auth()->user()->date_time_format)->sortable(),
             ])
             ->filters([
                 Tables\Filters\Filter::make('is_published')

--- a/app/Filament/Resources/CommentResource.php
+++ b/app/Filament/Resources/CommentResource.php
@@ -43,7 +43,7 @@ class CommentResource extends Resource
                 Tables\Columns\TextColumn::make('content')->wrap()->searchable(),
                 Tables\Columns\TextColumn::make('item.title'),
                 Tables\Columns\TextColumn::make('user.name'),
-                Tables\Columns\TextColumn::make('created_at')->dateTime()->sortable()->label('Date'),
+                Tables\Columns\TextColumn::make('created_at')->dateTime(Auth()->user()->date_time_format)->sortable()->label('Date'),
             ])
             ->filters([
                 //

--- a/app/Filament/Resources/InboxResource.php
+++ b/app/Filament/Resources/InboxResource.php
@@ -52,7 +52,7 @@ class InboxResource extends Resource
                 Tables\Columns\TextColumn::make('comments_count')->label(ucfirst(trans_choice('messages.comments', 2)))->counts('comments'),
                 Tables\Columns\TextColumn::make('user.name'),
                 Tables\Columns\TextColumn::make('created_at')
-                    ->dateTime()
+                    ->dateTime(Auth()->user()->date_time_format)
                     ->sortable()
                     ->label('Date'),
             ])

--- a/app/Filament/Resources/InboxResource/RelationManagers/CommentsRelationManager.php
+++ b/app/Filament/Resources/InboxResource/RelationManagers/CommentsRelationManager.php
@@ -44,7 +44,7 @@ class CommentsRelationManager extends HasManyRelationManager
             ->columns([
                 Tables\Columns\TextColumn::make('content')->searchable(),
                 Tables\Columns\TextColumn::make('user.name'),
-                Tables\Columns\TextColumn::make('created_at')->dateTime()->sortable()->label('Date'),
+                Tables\Columns\TextColumn::make('created_at')->dateTime(Auth()->user()->date_time_format)->sortable()->label('Date'),
             ])
             ->filters([
                 //

--- a/app/Filament/Resources/InboxResource/RelationManagers/VotesRelationManager.php
+++ b/app/Filament/Resources/InboxResource/RelationManagers/VotesRelationManager.php
@@ -26,7 +26,7 @@ class VotesRelationManager extends HasManyRelationManager
         return $table
             ->columns([
                 Tables\Columns\TextColumn::make('user.name'),
-                Tables\Columns\TextColumn::make('created_at')->dateTime()->sortable()->label('Date'),
+                Tables\Columns\TextColumn::make('created_at')->dateTime(Auth()->user()->date_time_format)->sortable()->label('Date'),
             ])
             ->filters([
                 //

--- a/app/Filament/Resources/ItemResource/RelationManagers/ActivitiesRelationManager.php
+++ b/app/Filament/Resources/ItemResource/RelationManagers/ActivitiesRelationManager.php
@@ -28,7 +28,7 @@ class ActivitiesRelationManager extends MorphManyRelationManager
             ->columns([
                 Tables\Columns\TextColumn::make('causer.name'),
                 Tables\Columns\TextColumn::make('description'),
-                Tables\Columns\TextColumn::make('created_at')->dateTime()->sortable()->label('Date'),
+                Tables\Columns\TextColumn::make('created_at')->dateTime(Auth()->user()->date_time_format)->sortable()->label('Date'),
             ])
             ->filters([
                 //

--- a/app/Filament/Resources/ItemResource/RelationManagers/CommentsRelationManager.php
+++ b/app/Filament/Resources/ItemResource/RelationManagers/CommentsRelationManager.php
@@ -44,7 +44,7 @@ class CommentsRelationManager extends HasManyRelationManager
             ->columns([
                 Tables\Columns\TextColumn::make('content')->searchable(),
                 Tables\Columns\TextColumn::make('user.name'),
-                Tables\Columns\TextColumn::make('created_at')->dateTime()->sortable()->label('Date'),
+                Tables\Columns\TextColumn::make('created_at')->dateTime(Auth()->user()->date_time_format)->sortable()->label('Date'),
             ])
             ->filters([
                 //

--- a/app/Filament/Resources/ItemResource/RelationManagers/VotesRelationManager.php
+++ b/app/Filament/Resources/ItemResource/RelationManagers/VotesRelationManager.php
@@ -34,7 +34,7 @@ class VotesRelationManager extends HasManyRelationManager
         return $table
             ->columns([
                 Tables\Columns\TextColumn::make('user.name'),
-                Tables\Columns\TextColumn::make('created_at')->dateTime()->sortable()->label('Date'),
+                Tables\Columns\TextColumn::make('created_at')->dateTime(Auth()->user()->date_time_format)->sortable()->label('Date'),
                 Tables\Columns\BooleanColumn::make('subscribed')->label('Subscribed'),
             ])
             ->filters([

--- a/app/Filament/Resources/ProjectResource.php
+++ b/app/Filament/Resources/ProjectResource.php
@@ -93,7 +93,7 @@ class ProjectResource extends Resource
                 Tables\Columns\TextColumn::make('title')->searchable(),
                 Tables\Columns\TextColumn::make('boards_count')->counts('boards'),
                 Tables\Columns\BooleanColumn::make('private'),
-                Tables\Columns\TextColumn::make('created_at')->dateTime()->label('Date'),
+                Tables\Columns\TextColumn::make('created_at')->dateTime(Auth()->user()->date_time_format)->label('Date'),
             ])
             ->filters([
                 //

--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -43,7 +43,7 @@ class UserResource extends Resource
                 Tables\Columns\TextColumn::make('name')->searchable(),
                 Tables\Columns\TextColumn::make('email')->searchable(),
                 Tables\Columns\TextColumn::make('role'),
-                Tables\Columns\TextColumn::make('created_at')->sortable()->dateTime()->label('Date'),
+                Tables\Columns\TextColumn::make('created_at')->sortable()->dateTime(Auth()->user()->date_time_format)->label('Date'),
             ])
             ->filters([
                 //

--- a/app/Filament/Resources/UserResource/RelationManagers/CommentsRelationManager.php
+++ b/app/Filament/Resources/UserResource/RelationManagers/CommentsRelationManager.php
@@ -44,7 +44,7 @@ class CommentsRelationManager extends HasManyRelationManager
             ->columns([
                 Tables\Columns\TextColumn::make('content')->searchable(),
                 Tables\Columns\TextColumn::make('item.title'),
-                Tables\Columns\TextColumn::make('created_at')->dateTime()->sortable()->label('Date'),
+                Tables\Columns\TextColumn::make('created_at')->dateTime(Auth()->user()->date_time_format)->sortable()->label('Date'),
             ])
             ->filters([
                 //

--- a/app/Filament/Resources/UserResource/RelationManagers/ItemsRelationManager.php
+++ b/app/Filament/Resources/UserResource/RelationManagers/ItemsRelationManager.php
@@ -48,7 +48,7 @@ class ItemsRelationManager extends HasManyRelationManager
                 Tables\Columns\TextColumn::make('board.project.title'),
                 Tables\Columns\TextColumn::make('board.title'),
                 Tables\Columns\TextColumn::make('created_at')
-                    ->dateTime()
+                    ->dateTime(Auth()->user()->date_time_format)
                     ->sortable()
                     ->label('Date'),
             ])

--- a/app/Filament/Resources/VoteResource.php
+++ b/app/Filament/Resources/VoteResource.php
@@ -33,7 +33,7 @@ class VoteResource extends Resource
                 Tables\Columns\TextColumn::make('user.name'),
                 Tables\Columns\TextColumn::make('model.title')->label('Item'),
                 Tables\Columns\BooleanColumn::make('subscribed'),
-                Tables\Columns\TextColumn::make('created_at')->dateTime()->sortable()->label('Date'),
+                Tables\Columns\TextColumn::make('created_at')->dateTime(Auth()->user()->date_time_format)->sortable()->label('Date'),
             ])
             ->filters([
                 //

--- a/app/Http/Livewire/My.php
+++ b/app/Http/Livewire/My.php
@@ -49,7 +49,7 @@ class My extends Component implements HasTable
 
                     return trans('table.created_at');
                 })
-                ->dateTime(),
+                ->dateTime(Auth()->user()->date_time_format),
         ];
     }
 

--- a/app/Http/Livewire/Profile.php
+++ b/app/Http/Livewire/Profile.php
@@ -147,6 +147,7 @@ class Profile extends Component implements HasForms, HasTable
         return [
             Tables\Columns\TextColumn::make('name'),
             Tables\Columns\TextColumn::make('provider'),
+            Tables\Columns\TextColumn::make('created_at')->label('Date')->sortable()->dateTime(Auth()->user()->date_time_format),
         ];
     }
 

--- a/app/Http/Livewire/Profile.php
+++ b/app/Http/Livewire/Profile.php
@@ -33,6 +33,7 @@ class Profile extends Component implements HasForms, HasTable
             'username' => $this->user->username,
             'email' => $this->user->email,
             'notification_settings' => $this->user->notification_settings,
+            'date_time_format' => $this->user->date_time_format,
         ]);
     }
 
@@ -60,6 +61,21 @@ class Profile extends Component implements HasForms, HasTable
                             'receive_comment_reply_notifications' => trans('profile.receive_comment_reply_notifications'),
                         ]),
                 ])->collapsible(),
+
+            Forms\Components\Section::make(trans('profile.settings'))
+                ->schema([
+                    Forms\Components\Select::make('date_time_format')->label(trans('profile.date_format'))
+                        ->options(
+                            [
+                                'Y-m-d H:i:s' => now()->format('Y-m-d H:i:s'),
+                                'm-d-Y H:i:s' => now()->format('m-d-Y H:i:s'),
+                                'd-m-Y H:i:s' => now()->format('d-m-Y H:i:s'),
+                                'Y-m-d h:i:s A' => now()->format('Y-m-d h:i:s A'),
+                                'm-d-Y h:i:s A' => now()->format('m-d-Y h:i:s A'),
+                                'd-m-Y h:i:s A' => now()->format('d-m-Y h:i:s A'),
+                            ]
+                        ),
+                ])
         ];
     }
 
@@ -72,6 +88,7 @@ class Profile extends Component implements HasForms, HasTable
             'email' => $data['email'],
             'username' => $data['username'],
             'notification_settings' => $data['notification_settings'],
+            'date_time_format' => $data['date_time_format']
         ]);
 
         $this->notify('success', 'Profile has been saved.');
@@ -130,7 +147,6 @@ class Profile extends Component implements HasForms, HasTable
         return [
             Tables\Columns\TextColumn::make('name'),
             Tables\Columns\TextColumn::make('provider'),
-            Tables\Columns\TextColumn::make('created_at')->label('Date')->sortable()->dateTime(),
         ];
     }
 

--- a/app/Http/Livewire/RecentMentions.php
+++ b/app/Http/Livewire/RecentMentions.php
@@ -28,7 +28,7 @@ class RecentMentions extends Component implements HasTable
         return [
             Tables\Columns\TextColumn::make('content')->wrap()->label(trans('table.content'))->searchable(),
             Tables\Columns\TextColumn::make('item.title')->label(trans('table.title'))->searchable(),
-            Tables\Columns\TextColumn::make('created_at')->dateTime()->sortable()->label(trans('table.created_at')),
+            Tables\Columns\TextColumn::make('created_at')->dateTime(Auth()->user()->date_time_format)->sortable()->label(trans('table.created_at')),
         ];
     }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -26,6 +26,7 @@ class User extends Authenticatable implements FilamentUser, HasAvatar, MustVerif
         'username',
         'password',
         'notification_settings',
+        'date_time_format',
     ];
 
     protected $hidden = [

--- a/database/migrations/2022_09_01_013943_add_date_time_format_column.php
+++ b/database/migrations/2022_09_01_013943_add_date_time_format_column.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('date_time_format')->nullable()->after('notification_settings');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            //
+        });
+    }
+};

--- a/lang/en/profile.php
+++ b/lang/en/profile.php
@@ -19,6 +19,6 @@ return [
     'social-login' => 'Social login',
     'social-login-description' => 'Here you\'ll find the social login\'s you\'ve used to log in with your account.',
     'settings' => 'Settings',
-    'date_format'=> 'Date Time format setting'
+    'date_format'=> 'Date Time format setting',
     'per_page_setting' => 'Per page setting',
 ];

--- a/lang/en/profile.php
+++ b/lang/en/profile.php
@@ -18,4 +18,6 @@ return [
     'receive_comment_reply_notifications' => 'Receive comment reply notifications',
     'social-login' => 'Social login',
     'social-login-description' => 'Here you\'ll find the social login\'s you\'ve used to log in with your account.',
+    'settings' => 'Settings',
+    'date_format'=> 'Date Time format setting'
 ];


### PR DESCRIPTION
This PR allows users to customise their date time format, I have provided 6 options, if the number of options were to be expanded then the method of selection would need to change.

I have applied the users date format to all filament `datetime()` methods.

I have not applied it to the dates using Iso format.

There is already a fallback format applied via the .env file or tables config file.