### PR TITLE
Localize dates

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -37,6 +37,7 @@ class Kernel extends HttpKernel
             \App\Http\Middleware\VerifyCsrfToken::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
             \App\Http\Middleware\PasswordProtected::class,
+            \App\Http\Middleware\LocalizeDates::class,
         ],
 
         'authed' => [

--- a/app/Http/Livewire/My.php
+++ b/app/Http/Livewire/My.php
@@ -8,6 +8,7 @@ use Livewire\Component;
 use Filament\Tables\Contracts\HasTable;
 use Illuminate\Database\Eloquent\Builder;
 use Filament\Tables\Concerns\InteractsWithTable;
+use Illuminate\Support\Carbon;
 
 class My extends Component implements HasTable
 {
@@ -49,7 +50,7 @@ class My extends Component implements HasTable
 
                     return trans('table.created_at');
                 })
-                ->dateTime(),
+                ->formatStateUsing(fn (Carbon $state) => $state->isoFormat('L LTS')),
         ];
     }
 

--- a/app/Http/Livewire/My.php
+++ b/app/Http/Livewire/My.php
@@ -50,7 +50,7 @@ class My extends Component implements HasTable
 
                     return trans('table.created_at');
                 })
-                ->formatStateUsing(fn (Carbon $state) => $state->isoFormat('L LTS')),
+                ->formatStateUsing(fn (Carbon|string $state) => (is_string($state) ? Carbon::parse($state) : $state)->isoFormat('L LTS')),
         ];
     }
 

--- a/app/Http/Livewire/Profile.php
+++ b/app/Http/Livewire/Profile.php
@@ -53,7 +53,7 @@ class Profile extends Component implements HasForms, HasTable
                     ])
                     ->unique(table: User::class, column: 'username', ignorable: auth()->user()),
                 Forms\Components\TextInput::make('email')->label(trans('auth.email'))->required()->email(),
-                Forms\Components\Select::make('date_locale')->label(trans('auth.date_locale'))->required()->options($this->locales),
+                Forms\Components\Select::make('date_locale')->label(trans('auth.date_locale'))->options($this->locales)->placeholder(trans('auth.date_locale_null_value')),
             ])->collapsible(),
 
             Forms\Components\Section::make(trans('profile.notifications'))

--- a/app/Http/Livewire/Profile.php
+++ b/app/Http/Livewire/Profile.php
@@ -3,6 +3,7 @@
 namespace App\Http\Livewire;
 
 use Filament\Forms;
+use ResourceBundle;
 use App\Models\User;
 use Filament\Tables;
 use Livewire\Component;
@@ -33,7 +34,8 @@ class Profile extends Component implements HasForms, HasTable
             'username' => $this->user->username,
             'email' => $this->user->email,
             'notification_settings' => $this->user->notification_settings,
-            'per_page_setting' => $this->user->per_page_setting ?? [5]
+            'per_page_setting' => $this->user->per_page_setting ?? [5],
+            'date_locale' => $this->user->date_locale,
         ]);
     }
 
@@ -51,6 +53,7 @@ class Profile extends Component implements HasForms, HasTable
                     ])
                     ->unique(table: User::class, column: 'username', ignorable: auth()->user()),
                 Forms\Components\TextInput::make('email')->label(trans('auth.email'))->required()->email(),
+                Forms\Components\Select::make('date_locale')->label(trans('auth.date_locale'))->required()->options($this->locales),
             ])->collapsible(),
 
             Forms\Components\Section::make(trans('profile.notifications'))
@@ -89,6 +92,7 @@ class Profile extends Component implements HasForms, HasTable
             'username' => $data['username'],
             'notification_settings' => $data['notification_settings'],
             'per_page_setting' => $data['per_page_setting'],
+            'date_locale' => $data['date_locale'],
         ]);
 
         $this->notify('success', 'Profile has been saved.');
@@ -128,6 +132,15 @@ class Profile extends Component implements HasForms, HasTable
         auth()->logout();
 
         return redirect()->route('home');
+    }
+
+    public function getLocalesProperty(): array
+    {
+        $locales = ResourceBundle::getLocales('');
+
+        return collect($locales)
+            ->mapWithKeys(fn ($locale) => [$locale => $locale])
+            ->toArray();
     }
 
     public function render()

--- a/app/Http/Middleware/LocalizeDates.php
+++ b/app/Http/Middleware/LocalizeDates.php
@@ -18,7 +18,7 @@ class LocalizeDates
     public function handle(Request $request, Closure $next)
     {
         if (auth()->check()) {
-            Carbon::setLocale(auth()->user()->date_locale);
+            Carbon::setLocale(auth()->user()->date_locale ?? config('app.locale'));
         }
 
         return $next($request);

--- a/app/Http/Middleware/LocalizeDates.php
+++ b/app/Http/Middleware/LocalizeDates.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+
+class LocalizeDates
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure(\Illuminate\Http\Request): (\Illuminate\Http\Response|\Illuminate\Http\RedirectResponse)  $next
+     * @return \Illuminate\Http\Response|\Illuminate\Http\RedirectResponse
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        if (auth()->check()) {
+            Carbon::setLocale(auth()->user()->date_locale);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -26,7 +26,8 @@ class User extends Authenticatable implements FilamentUser, HasAvatar, MustVerif
         'username',
         'password',
         'notification_settings',
-        'per_page_setting'
+        'per_page_setting',
+        'date_locale',
     ];
 
     protected $hidden = [

--- a/database/migrations/2022_10_18_104540_add_date_locale_to_users_table.php
+++ b/database/migrations/2022_10_18_104540_add_date_locale_to_users_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('date_locale')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            //
+        });
+    }
+};

--- a/database/migrations/2022_10_18_104540_add_date_locale_to_users_table.php
+++ b/database/migrations/2022_10_18_104540_add_date_locale_to_users_table.php
@@ -14,7 +14,7 @@ return new class extends Migration
     public function up()
     {
         Schema::table('users', function (Blueprint $table) {
-            $table->string('date_locale')->nullable();
+            $table->string('date_locale')->nullable()->after('remember_token');
         });
     }
 

--- a/database/migrations/2022_10_18_104540_add_date_locale_to_users_table.php
+++ b/database/migrations/2022_10_18_104540_add_date_locale_to_users_table.php
@@ -14,7 +14,7 @@ return new class extends Migration
     public function up()
     {
         Schema::table('users', function (Blueprint $table) {
-            $table->string('date_locale')->default('en')->after('remember_token');
+            $table->string('date_locale')->nullable()->after('remember_token');
         });
     }
 

--- a/database/migrations/2022_10_18_104540_add_date_locale_to_users_table.php
+++ b/database/migrations/2022_10_18_104540_add_date_locale_to_users_table.php
@@ -14,7 +14,7 @@ return new class extends Migration
     public function up()
     {
         Schema::table('users', function (Blueprint $table) {
-            $table->string('date_locale')->nullable()->after('remember_token');
+            $table->string('date_locale')->default('en')->after('remember_token');
         });
     }
 

--- a/lang/en/auth.php
+++ b/lang/en/auth.php
@@ -5,7 +5,7 @@ return [
     'verify-email' => 'Verify email',
     'register' => 'Register',
     'profile' => 'Profile',
-    'register_for_free' => 'Or <a class="text-brand-600 transition hover:text-brand-500 focus:outline-none focus:underline" href=":route">register</a> for free.',
+    'register_for_free' => 'Or <a class="transition text-brand-600 hover:text-brand-500 focus:outline-none focus:underline" href=":route">register</a> for free.',
     'not_new' => 'Not new here?',
     'password_protected' => 'Password protected',
 
@@ -24,5 +24,7 @@ return [
 
     'failed' => 'These credentials do not match our records.',
     'throttle' => 'Too many login attempts. Please try again in :seconds seconds.',
+
+    'date_locale' => 'Date locale',
 
 ];

--- a/lang/en/auth.php
+++ b/lang/en/auth.php
@@ -26,5 +26,6 @@ return [
     'throttle' => 'Too many login attempts. Please try again in :seconds seconds.',
 
     'date_locale' => 'Date locale',
+    'date_locale_null_value' => 'Use app locale',
 
 ];

--- a/lang/nl/auth.php
+++ b/lang/nl/auth.php
@@ -36,5 +36,6 @@ return [
     'failed'   => 'Deze combinatie van e-mailadres en wachtwoord is niet geldig.',
     'throttle' => 'Te veel mislukte aanmeldpogingen. Probeer het over nog eens over :seconds seconden.',
 
-    'date_locale' => 'Datum & tijd vertaling'
+    'date_locale' => 'Datum & tijd vertaling',
+    'date_locale_null_value' => 'Gebruik app voorkeurstaal',
 ];

--- a/lang/nl/auth.php
+++ b/lang/nl/auth.php
@@ -16,7 +16,7 @@ return [
     'verify-email' => 'Verifieer email',
     'register' => 'Registreren',
     'profile' => 'Profiel',
-    'register_for_free' => 'Of <a class="text-brand-600 transition hover:text-brand-500 focus:outline-none focus:underline" href=":route">maak een gratis account aan</a>.',
+    'register_for_free' => 'Of <a class="transition text-brand-600 hover:text-brand-500 focus:outline-none focus:underline" href=":route">maak een gratis account aan</a>.',
     'not_new' => 'Niet nieuw hier?',
     'password_protected' => 'Beschermd met een wachtwoord',
 
@@ -35,4 +35,6 @@ return [
 
     'failed'   => 'Deze combinatie van e-mailadres en wachtwoord is niet geldig.',
     'throttle' => 'Te veel mislukte aanmeldpogingen. Probeer het over nog eens over :seconds seconden.',
+
+    'date_locale' => 'Datum & tijd vertaling'
 ];


### PR DESCRIPTION
Allow users to localize dates (apart from app localization)

- Uses PHP built in `ResourceBundle::getLocales` to fetch locales
- Date locale is being set via middleware